### PR TITLE
Improve handling sys-usb creation

### DIFF
--- a/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
+++ b/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
@@ -415,6 +415,12 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
             dependencies=[self.choice_usb],
             indent=True
         )
+        self.choice_allow_usb_mouse = QubesChoice(
+            location=self.mainBox,
+            label=_("Automatically accept USB mice (discouraged)"),
+            dependencies=[self.choice_usb],
+            indent=True
+        )
 
         if self.qubes_data.whonix_available:
             self.choice_whonix = QubesChoice(
@@ -550,6 +556,7 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         self.choice_usb.set_selected(self.qubes_data.usbvm)
         self.choice_usb_with_netvm.set_selected(
             self.qubes_data.usbvm_with_netvm)
+        self.choice_allow_usb_mouse.set_selected(self.qubes_data.allow_usb_mouse)
 
         self.choice_custom_pool.set_selected(self.qubes_data.custom_pool)
         if self.qubes_data.vg_tpool and \
@@ -590,6 +597,7 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
 
         self.qubes_data.usbvm = self.choice_usb.get_selected()
         self.qubes_data.usbvm_with_netvm = self.choice_usb_with_netvm.get_selected()
+        self.qubes_data.allow_usb_mouse = self.choice_allow_usb_mouse.get_selected()
 
         self.qubes_data.whonix_vms = self.choice_whonix.get_selected()
         self.qubes_data.whonix_default = self.choice_whonix_updates.get_selected()

--- a/org_qubes_os_initial_setup/ks/qubes.py
+++ b/org_qubes_os_initial_setup/ks/qubes.py
@@ -104,7 +104,8 @@ class QubesData(AddonData):
 
     bool_options = (
         'system_vms', 'disp_firewallvm_and_usbvm', 'disp_netvm','default_vms',
-        'whonix_vms', 'whonix_default', 'usbvm', 'usbvm_with_netvm', 'skip'
+        'whonix_vms', 'whonix_default', 'usbvm', 'usbvm_with_netvm', 'skip',
+        'allow_usb_mouse',
     )
 
     def __init__(self, name):
@@ -150,6 +151,7 @@ class QubesData(AddonData):
 
         self.usbvm = self.usbvm_available
         self.usbvm_with_netvm = False
+        self.allow_usb_mouse = False
 
         self.custom_pool = False
         self.vg_tpool = self.get_default_tpool()
@@ -435,6 +437,8 @@ class QubesData(AddonData):
             states.append('qvm.sys-usb')
         if self.usbvm_with_netvm:
             states.append('pillar.qvm.sys-net-as-usbvm')
+        if self.allow_usb_mouse:
+            states.append('pillar.qvm.sys-usb-allow-mouse')
 
         try:
             # get rid of initial entries (from package installation time)

--- a/org_qubes_os_initial_setup/tui/spokes/qubes_os.py
+++ b/org_qubes_os_initial_setup/tui/spokes/qubes_os.py
@@ -163,6 +163,11 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalTUISpoke):
                 title=_('Use sys-net qube for both networking and USB devices'),
                 completed=self._usbvm_with_netvm)
             self._container.add(w, self._set_checkbox, '_usbvm_with_netvm')
+        if self._usbvm:
+            w = CheckboxWidget(
+                title=_('Automatically accept USB mice (discouraged)'),
+                completed=self._allow_usb_mouse)
+            self._container.add(w, self._set_checkbox, '_allow_usb_mouse')
 
         self.window.add_with_separator(self._container)
 


### PR DESCRIPTION
1. Add option to automatically accept USB mice
2. Do not prevent creating sys-usb, if controllers with HID remains in dom0

QubesOS/qubes-issues#3722
QubesOS/qubes-issues#2116