### PR TITLE
Allow enabling sys-usb even if USB keyboard is detected

### DIFF
--- a/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
+++ b/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
@@ -421,6 +421,12 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
             dependencies=[self.choice_usb],
             indent=True
         )
+        self.choice_allow_usb_keyboard = QubesChoice(
+            location=self.mainBox,
+            label=_("Automatically accept USB keyboard (discouraged if non-USB keyboard is available)"),
+            dependencies=[self.choice_usb],
+            indent=True
+        )
 
         if self.qubes_data.whonix_available:
             self.choice_whonix = QubesChoice(
@@ -557,6 +563,7 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         self.choice_usb_with_netvm.set_selected(
             self.qubes_data.usbvm_with_netvm)
         self.choice_allow_usb_mouse.set_selected(self.qubes_data.allow_usb_mouse)
+        self.choice_allow_usb_keyboard.set_selected(self.qubes_data.allow_usb_keyboard)
 
         self.choice_custom_pool.set_selected(self.qubes_data.custom_pool)
         if self.qubes_data.vg_tpool and \

--- a/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
+++ b/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
@@ -115,6 +115,28 @@ class QubesChoice(QubesChoiceBase):
         self.set_sensitive(self.are_dependencies_selected())
 
 
+class ChoiceMessage(QubesChoiceBase):
+
+    def __init__(self, location=None, indent=False, choice_type=None, icon_name=None):
+        self.widget = Gtk.Box()
+        if icon_name:
+            icon = Gtk.IconTheme.get_default().load_icon(icon_name, 30, 0)
+            icon_img = Gtk.Image.new_from_pixbuf(icon)
+            self.widget.pack_start(icon_img, False, False, 0)
+        self.label_widget = Gtk.Label()
+        self.label_widget.set_xalign(0)
+        self.label_widget.set_padding(0, 10)
+        self.label_widget.set_line_wrap(True)
+        self.widget.pack_start(self.label_widget, False, True, 10)
+        self.widget.show_all()
+        self.widget.set_no_show_all(True)
+        super().__init__(widget=self.widget,
+                         location=location,
+                         indent=indent,
+                         choice_type=choice_type)
+        choices_instances.append(self)
+
+
 class DisabledChoice(QubesChoice):
 
     def __init__(self, location, label, indent=False):
@@ -427,6 +449,11 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
             dependencies=[self.choice_usb],
             indent=True
         )
+        self.usb_keyboards_list = ChoiceMessage(
+            location=self.mainBox,
+            indent=True,
+            icon_name='help-about',
+        )
 
         if self.qubes_data.whonix_available:
             self.choice_whonix = QubesChoice(
@@ -564,6 +591,14 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
             self.qubes_data.usbvm_with_netvm)
         self.choice_allow_usb_mouse.set_selected(self.qubes_data.allow_usb_mouse)
         self.choice_allow_usb_keyboard.set_selected(self.qubes_data.allow_usb_keyboard)
+        if self.qubes_data.usb_keyboards_detected:
+            self.usb_keyboards_list.label_widget.set_markup(
+                _("<b>INFO:</b> the following USB keyboards will be connected to sys-usb:\n{}\n"
+                  "<b>If you disable the option above, they will not function in Qubes.</b>").format(
+                    '\n'.join('- {}'.format(k) for k in self.qubes_data.usb_keyboards_detected)
+                ))
+        self.usb_keyboards_list.widget.set_visible(
+            bool(self.qubes_data.usb_keyboards_detected))
 
         self.choice_custom_pool.set_selected(self.qubes_data.custom_pool)
         if self.qubes_data.vg_tpool and \

--- a/org_qubes_os_initial_setup/ks/qubes.py
+++ b/org_qubes_os_initial_setup/ks/qubes.py
@@ -120,7 +120,7 @@ class QubesData(AddonData):
     bool_options = (
         'system_vms', 'disp_firewallvm_and_usbvm', 'disp_netvm','default_vms',
         'whonix_vms', 'whonix_default', 'usbvm', 'usbvm_with_netvm', 'skip',
-        'allow_usb_mouse',
+        'allow_usb_mouse', 'allow_usb_keyboard',
     )
 
     def __init__(self, name):
@@ -152,8 +152,7 @@ class QubesData(AddonData):
             self.templates_versions['whonix'] = get_template_version('whonix-ws')
             self.templates_aliases['whonix'] = 'Whonix %s' % self.templates_versions['whonix']
 
-        self.usbvm_available = (
-                not usb_keyboard_present() and not started_from_usb())
+        self.usbvm_available = not started_from_usb()
         self.system_vms = True
 
         self.disp_firewallvm_and_usbvm = True
@@ -167,6 +166,7 @@ class QubesData(AddonData):
         self.usbvm = self.usbvm_available
         self.usbvm_with_netvm = False
         self.allow_usb_mouse = False
+        self.allow_usb_keyboard = usb_keyboard_present()
 
         self.custom_pool = False
         self.vg_tpool = self.get_default_tpool()
@@ -454,6 +454,8 @@ class QubesData(AddonData):
             states.append('pillar.qvm.sys-net-as-usbvm')
         if self.allow_usb_mouse:
             states.append('pillar.qvm.sys-usb-allow-mouse')
+        if self.allow_usb_keyboard:
+            states.append('pillar.qvm.usb-keyboard')
 
         try:
             # get rid of initial entries (from package installation time)

--- a/qubes-anaconda-addon.spec.in
+++ b/qubes-anaconda-addon.spec.in
@@ -8,7 +8,7 @@ License:        GPLv2+
 BuildArch:      noarch
 BuildRequires:  python3
 Requires:       python3
-Requires:       qubes-mgmt-salt-dom0-virtual-machines >= 4.1.16
+Requires:       qubes-mgmt-salt-dom0-virtual-machines >= 4.1.19
 #Requires:       anaconda >= 19
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)


### PR DESCRIPTION
In addition to allowing sys-usb and input proxy for keyboard, show also a list
of impacted USB keyboards.

QubesOS/qubes-issues#7674