### PR TITLE
Rename short whonix-(gw|ws) names to their full names

### DIFF
--- a/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
+++ b/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
@@ -668,8 +668,8 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
 
         self.choice_install_whonix.set_selected(
             self.qubes_data.whonix_available
-            and "whonix-gw" in self.qubes_data.templates_to_install
-            and "whonix-ws" in self.qubes_data.templates_to_install
+            and "whonix-gateway" in self.qubes_data.templates_to_install
+            and "whonix-workstation" in self.qubes_data.templates_to_install
         )
 
         self.choice_system.set_selected(self.qubes_data.system_vms)
@@ -729,7 +729,7 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         if self.choice_install_debian.get_selected():
             templates_to_install.append("debian")
         if self.choice_install_whonix.get_selected():
-            templates_to_install += ["whonix-gw", "whonix-ws"]
+            templates_to_install += ["whonix-gateway", "whonix-workstation"]
 
         self.qubes_data.templates_to_install = templates_to_install
         for key, val in self.qubes_data.templates_aliases.items():

--- a/org_qubes_os_initial_setup/service/kickstart.py
+++ b/org_qubes_os_initial_setup/service/kickstart.py
@@ -71,7 +71,7 @@ class QubesData(AddonData):
         self.skip = False
 
         self.default_template = None
-        self.templates_to_install = ["fedora", "debian", "whonix-gw", "whonix-ws"]
+        self.templates_to_install = ["fedora", "debian", "whonix-gateway", "whonix-workstation"]
 
         self.qubes_user = None
 

--- a/org_qubes_os_initial_setup/service/qubes.py
+++ b/org_qubes_os_initial_setup/service/qubes.py
@@ -77,9 +77,9 @@ class QubesInitialSetup(KickstartService):
         super().__init__()
         self.fedora_available = is_template_rpm_available("fedora")
         self.debian_available = is_template_rpm_available("debian")
-        self.whonix_available = is_template_rpm_available(
-            "whonix-gw"
-        ) and is_template_rpm_available("whonix-ws")
+        self.whonix_available = (
+                is_template_rpm_available("whonix-gateway") and
+                is_template_rpm_available("whonix-workstation"))
 
         self.templates_aliases = {}
         self.templates_versions = {}
@@ -96,7 +96,9 @@ class QubesInitialSetup(KickstartService):
             )
 
         if self.whonix_available:
-            self.templates_versions["whonix"] = get_template_version("whonix-ws")
+            self.templates_versions["whonix"] = (
+                get_template_version("whonix-workstation")
+            )
             self.templates_aliases["whonix"] = (
                 "Whonix %s" % self.templates_versions["whonix"]
             )
@@ -135,7 +137,7 @@ class QubesInitialSetup(KickstartService):
         self._skip = False
 
         self._default_template = None
-        self._templates_to_install = ["fedora", "debian", "whonix-gw", "whonix-ws"]
+        self._templates_to_install = ["fedora", "debian", "whonix-gateway", "whonix-workstation"]
 
         self.qubes_user = None
 

--- a/org_qubes_os_initial_setup/service/tasks.py
+++ b/org_qubes_os_initial_setup/service/tasks.py
@@ -150,10 +150,7 @@ class InstallTemplateTask(BaseQubesTask):
 
     def run(self):
         template = self.template
-        if template.startswith("whonix"):
-            template_version = get_template_version("whonix-ws")
-        else:
-            template_version = get_template_version(template)
+        template_version = get_template_version(template)
         template_name = "%s-%s" % (template, template_version)
         self.report_progress("Installing TemplateVM %s" % template_name)
         rpm = get_template_rpm(template)


### PR DESCRIPTION
Whonix 17 use full "workstation" and "gateway" names, instead of whort
"ws" and "gw" versions. Rename all template name instances.

QubesOS/qubes-issues#1778