### PR TITLE
Rework handling templates to support different flavors

### DIFF
--- a/org_qubes_os_initial_setup/service/kickstart.py
+++ b/org_qubes_os_initial_setup/service/kickstart.py
@@ -67,6 +67,7 @@ class QubesData(AddonData):
         self.allow_usb_keyboard = None
 
         self.vg_tpool = None
+        self.create_default_tpool = True
 
         self.skip = False
 

--- a/org_qubes_os_initial_setup/service/kickstart.py
+++ b/org_qubes_os_initial_setup/service/kickstart.py
@@ -71,7 +71,7 @@ class QubesData(AddonData):
         self.skip = False
 
         self.default_template = None
-        self.templates_to_install = ["fedora", "debian", "whonix-gateway", "whonix-workstation"]
+        self.templates_to_install = None
 
         self.qubes_user = None
 

--- a/org_qubes_os_initial_setup/service/qubes_interface.py
+++ b/org_qubes_os_initial_setup/service/qubes_interface.py
@@ -199,14 +199,6 @@ class QubesInitialSetupInterface(KickstartModuleInterface):
         return self.implementation.lvm_setup
 
     @property
-    def FedoraAvailable(self) -> bool:
-        return self.implementation.fedora_available
-
-    @property
-    def DebianAvailable(self) -> bool:
-        return self.implementation.debian_available
-
-    @property
     def WhonixAvailable(self) -> bool:
         return self.implementation.whonix_available
 

--- a/org_qubes_os_initial_setup/service/tasks.py
+++ b/org_qubes_os_initial_setup/service/tasks.py
@@ -27,7 +27,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.task import Task
 
 from org_qubes_os_initial_setup.constants import TEMPLATES_RPM_PATH
-from org_qubes_os_initial_setup.utils import get_template_version, get_template_rpm
+from org_qubes_os_initial_setup.utils import get_template_name, get_template_rpm
 
 log = logging.getLogger(__name__)
 
@@ -150,8 +150,7 @@ class InstallTemplateTask(BaseQubesTask):
 
     def run(self):
         template = self.template
-        template_version = get_template_version(template)
-        template_name = "%s-%s" % (template, template_version)
+        template_name = get_template_name(template)
         self.report_progress("Installing TemplateVM %s" % template_name)
         rpm = get_template_rpm(template)
         self.run_command(["/usr/bin/qvm-template", "install", "--nogpgcheck", rpm])

--- a/org_qubes_os_initial_setup/service/tasks.py
+++ b/org_qubes_os_initial_setup/service/tasks.py
@@ -16,11 +16,11 @@
 #
 # You should have received a copy of the GNU General Public
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
-import distutils.version
 import logging
 import os
 import shutil
 import subprocess
+from looseversion import LooseVersion
 
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
@@ -74,9 +74,7 @@ class DefaultKernelTask(BaseQubesTask):
     def run(self):
         installed_kernels = os.listdir("/var/lib/qubes/vm-kernels")
         installed_kernels = [
-            distutils.version.LooseVersion(x)
-            for x in installed_kernels
-            if x[0].isdigit()
+            LooseVersion(x) for x in installed_kernels if x[0].isdigit()
         ]
         default_kernel = str(sorted(installed_kernels)[-1])
         self.run_command(["/usr/bin/qubes-prefs", "default-kernel", default_kernel])

--- a/qubes-anaconda-addon.spec.in
+++ b/qubes-anaconda-addon.spec.in
@@ -8,6 +8,7 @@ License:        GPLv2+
 BuildArch:      noarch
 BuildRequires:  python3
 Requires:       python3
+Requires:       python3-looseversion
 Requires:       qubes-mgmt-salt-dom0-virtual-machines >= 4.1.19
 #Requires:       anaconda >= 19
 


### PR DESCRIPTION
Be more flexible about installed templates, instead of hardcoding list of them.
This also includes handling flavors, where template version is in the middle of
the name, not at the end.

QubesOS/qubes-issues#7784