### PR TITLE
Configure global preloaded disposables

### DIFF
--- a/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
+++ b/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
@@ -486,6 +486,23 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
             indent=True,
         )
 
+        if self.qubes_data.disp_preload_available:
+            self.choice_disp_preload = QubesButtonChoice(
+                location=self.mainBox,
+                label=_(
+                    "Preload disposable qubes based on the default DispVM (faster usage)"
+                ),
+                dependencies=[self.choice_system],
+                indent=True,
+            )
+        else:
+            label_prefix = "Preloading disposables not available "
+            label_suffix = "(not enough memory)"
+            self.choice_disp_preload = QubesDisabledButtonChoice(
+                location=self.mainBox, label=_(label_prefix + label_suffix),
+                indent=True,
+            )
+
         self.choice_default = QubesButtonChoice(
             location=self.mainBox,
             label=_(
@@ -603,6 +620,7 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         self.choice_system.widget.set_active(True)
 
         self.choice_disp_firewallvm_and_usbvm.widget.set_active(True)
+        self.choice_disp_preload.widget.set_active(self.qubes_data.disp_preload_available)
 
         self.choice_default.widget.set_active(True)
 
@@ -664,6 +682,7 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
             self.qubes_data.disp_firewallvm_and_usbvm
         )
         self.choice_disp_netvm.set_selected(self.qubes_data.disp_netvm)
+        self.choice_disp_preload.set_selected(self.qubes_data.disp_preload_available)
 
         self.choice_default.set_selected(self.qubes_data.default_vms)
 
@@ -728,6 +747,7 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
             self.choice_disp_firewallvm_and_usbvm.get_selected()
         )
         self.qubes_data.disp_netvm = self.choice_disp_netvm.get_selected()
+        self.qubes_data.disp_preload = self.choice_disp_preload.get_selected()
 
         self.qubes_data.default_vms = self.choice_default.get_selected()
 

--- a/org_qubes_os_initial_setup/service/kickstart.py
+++ b/org_qubes_os_initial_setup/service/kickstart.py
@@ -37,6 +37,7 @@ class QubesData(AddonData):
         "system_vms",
         "disp_firewallvm_and_usbvm",
         "disp_netvm",
+        "disp_preload",
         "default_vms",
         "whonix_vms",
         "whonix_default",
@@ -55,6 +56,7 @@ class QubesData(AddonData):
 
         self.disp_firewallvm_and_usbvm = True
         self.disp_netvm = False
+        self.disp_preload = None
 
         self.default_vms = True
 

--- a/org_qubes_os_initial_setup/service/qubes.py
+++ b/org_qubes_os_initial_setup/service/qubes.py
@@ -50,6 +50,7 @@ from org_qubes_os_initial_setup.utils import (
     get_default_tpool,
     get_templates_list,
     get_template_name,
+    is_disp_preload_available,
 )
 
 log = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ class QubesInitialSetup(KickstartService):
         "system_vms",
         "disp_firewallvm_and_usbvm",
         "disp_netvm",
+        "disp_preload",
         "default_vms",
         "whonix_vms",
         "whonix_default",
@@ -80,6 +82,7 @@ class QubesInitialSetup(KickstartService):
         self.whonix_available = is_template_rpm_available(
             "whonix-gateway"
         ) and is_template_rpm_available("whonix-workstation")
+        self.disp_preload_available = is_disp_preload_available()
 
         self.templates_aliases = {}
         for template, alias in get_templates_list():
@@ -99,6 +102,7 @@ class QubesInitialSetup(KickstartService):
 
         self._disp_firewallvm_and_usbvm = True
         self._disp_netvm = False
+        self._disp_preload = self.disp_preload_available
 
         self._default_vms = True
 
@@ -242,6 +246,7 @@ class QubesInitialSetup(KickstartService):
                 whonix_vms=self.whonix_vms,
                 default_vms=self.default_vms,
                 disp_netvm=self.disp_netvm,
+                disp_preload=self.disp_preload,
             )
         )
         if default_template:

--- a/org_qubes_os_initial_setup/service/qubes_interface.py
+++ b/org_qubes_os_initial_setup/service/qubes_interface.py
@@ -52,6 +52,7 @@ class QubesInitialSetupInterface(KickstartModuleInterface):
     #             ("system_vms", "Bool"),
     #             ("disp_firewallvm_and_usbvm", "Bool"),
     #             ("disp_netvm", "Bool"),
+    #             ("disp_preload", "Bool"),
     #             ("default_vms", "Bool"),
     #             ("whonix_vms", "Bool"),
     #             ("whonix_default", "Bool"),
@@ -96,6 +97,18 @@ class QubesInitialSetupInterface(KickstartModuleInterface):
     @DispNetvm.setter
     def DispNetvm(self, value: Bool):
         self.implementation.disp_netvm = value
+
+    @property
+    def DispPreloadAvailable(self) -> Bool:
+        return self.implementation.disp_preload_available
+
+    @property
+    def DispPreload(self) -> Bool:
+        return self.implementation.disp_preload
+
+    @DispPreload.setter
+    def DispPreload(self, value: Bool):
+        self.implementation.disp_preload = value
 
     @property
     def DefaultVms(self) -> Bool:

--- a/org_qubes_os_initial_setup/service/tasks.py
+++ b/org_qubes_os_initial_setup/service/tasks.py
@@ -214,6 +214,7 @@ class ConfigureDefaultQubesTask(BaseQubesTask):
         whonix_vms,
         default_vms,
         disp_netvm,
+        disp_preload,
     ):
         super().__init__()
         self.system_vms = system_vms
@@ -226,6 +227,7 @@ class ConfigureDefaultQubesTask(BaseQubesTask):
         self.whonix_vms = whonix_vms
         self.default_vms = default_vms
         self.disp_netvm = disp_netvm
+        self.disp_preload = disp_preload
 
     @property
     def name(self):
@@ -241,6 +243,8 @@ class ConfigureDefaultQubesTask(BaseQubesTask):
             )
         if self.disp_netvm:
             states.append("pillar.qvm.disposable-sys-net")
+        if self.disp_preload:
+            states.append("pillar.qvm.disposable-preload")
         if self.default_vms:
             states.extend(("qvm.personal", "qvm.work", "qvm.untrusted", "qvm.vault"))
         if self.whonix_vms:

--- a/org_qubes_os_initial_setup/tui/spokes/qubes_os.py
+++ b/org_qubes_os_initial_setup/tui/spokes/qubes_os.py
@@ -140,6 +140,14 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalTUISpoke):
                 title=_("Make sys-net disposable"), completed=self._disp_netvm
             )
             self._container.add(w, self._set_checkbox, "_disp_netvm")
+            if self.qubes_data.disp_preload_available:
+                title_begin = "Preload disposable qubes based on the default DispVM "
+                title_end = "(faster usage)"
+                w = CheckboxWidget(
+                    title=_(title_begin + title_end),
+                    completed=self._disp_preload,
+                )
+                self._container.add(w, self._set_checkbox, "_disp_preload")
         w = CheckboxWidget(
             title=_(
                 "Create default application qubes " "(personal, work, untrusted, vault)"

--- a/org_qubes_os_initial_setup/utils.py
+++ b/org_qubes_os_initial_setup/utils.py
@@ -182,6 +182,16 @@ def started_from_usb():
     return False
 
 
+def is_disp_preload_available() -> bool:
+    try:
+        total_memory = subprocess.check_output(["xl", "info", "total_memory"])
+        total_memory_megabytes = int(total_memory.decode("ascii"))
+    except subprocess.CalledProcessError:
+        return False
+    total_memory_gigabytes = int(total_memory_megabytes / 1000)
+    return bool(total_memory_gigabytes >= 16)
+
+
 def get_default_tpool():
     # get VG / pool where root filesystem lives
     fs_stat = os.stat("/")


### PR DESCRIPTION
For: https://github.com/QubesOS/qubes-issues/issues/1512
For: https://github.com/QubesOS/qubes-issues/issues/10078
Requires: https://github.com/QubesOS/qubes-mgmt-salt-dom0-virtual-machines/pull/77

---

Enabling fails on older ISO because it checks the default-dispvm supported-rpc.qubes.WaitForRunningSystem.

Checklist from installed system and fresh install:

- [x] checkbox marked if there is enough memory to preload, disabled otherwise
- [x] checkbox disabled when when unchecking *Create default system qubes*
- [x] proceeding with the checkbox marked, runs the salt state and sets the feature
- [x] proceeding with the checkbox unchecked, does not set the feature
